### PR TITLE
fixing image container in event display

### DIFF
--- a/_layouts/EventDisplay.html
+++ b/_layouts/EventDisplay.html
@@ -49,13 +49,14 @@ layout: default
   
 <style>
     .slick-slide img {
-    height:420px;
+    height:50vh;
+    object-fit:contain;
     }
 </style>
 <div class="slider-box _clearfix">
 <div class="slick-slides">
    {% for img in page.slides %}
-   <div class="image fit"><img src="{{ img }}" style="width: 100%; height: 100%"></div>
+   <div class="image fit"><img src="{{ img }}" style="width:100%"></div>
    {% endfor %}
    </div>
 </div>


### PR DESCRIPTION
I discovered this CSS3 property called `object-fit`. This solves everything.

Note:
The `width` needs to be `100%` for it to fit to all device widths.
The `height` is set to 50vh, which means 50% of device height will be occupied. Feel free to change this number. This can also be set in interesting ways, for example
`height:calc(50vh-100px);` I think it's obvious what this does. 