### PR TITLE
Automate deployment to GitHub Pages/Netlify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: generic
+language: ruby
+rvm:
+  - 2.4.4
+
+script:
+   - chmod +x build-gh-pages.sh && ./build-gh-pages.sh
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  keep-history: true
+  github-token: $GITHUB_TOKEN
+  local-dir: built
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 2.4.4
 
 script:
+   - gem update --system
+   - gem install bundler
    - chmod +x build-gh-pages.sh && ./build-gh-pages.sh
 
 deploy:

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem "jekyll"

--- a/_config.gh-pages.yml
+++ b/_config.gh-pages.yml
@@ -1,0 +1,25 @@
+# Site settings
+title: WnCC
+email: your-email@domain.com
+description: > # this means to ignore newlines until "baseurl:"
+  This is the official page for The Web and Coding Club of IIT Bombay.
+
+baseurl: "/WnCC" # the subpath of your site, e.g. /blog/
+url: "https://pulsejet.github.io" # the base hostname & protocol for your site
+twitter_username: wncc_iitb
+github_username:  wncc
+
+# Build Settings
+sass:
+  sass_dir: _sass
+include: ['_pages']
+kramdown:
+  input: GFM
+collections:
+  soc_projects:
+    output: true
+  showcase_projects:
+    output: true
+  events:
+    output: true
+

--- a/_config.gh-pages.yml
+++ b/_config.gh-pages.yml
@@ -13,6 +13,7 @@ github_username:  wncc
 sass:
   sass_dir: _sass
 include: ['_pages']
+exclude: ['*.yml', '*.sh']
 kramdown:
   input: GFM
 collections:

--- a/build-gh-pages.sh
+++ b/build-gh-pages.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir built
+gem install jekyll
+JEKYLL_ENV=production jekyll build --destination built --config _config.gh-pages.yml


### PR DESCRIPTION
This automates deployment to GitHub Pages with [Travis CI](https://travis-ci.org/). On every push, Travis will setup Jekyll, build and push to gh-pages. CD is live at https://pulsejet.github.io/WnCC/, for my fork at https://github.com/pulsejet/WnCC

This requires some setup. Specifically,
- [x] Add .travis.yml to the repo and a build script
- [ ] Set up Travis. This needs to be done by @nihal111 since creating webhooks needs `owner` permissions
- [ ] Create a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) for a user with write rights to the repo.
- [ ] Add this token as a secret environment variable to Travis with name `GITHUB_TOKEN`
- [ ] Merge this pull request into master
- [ ] Change `url` in `_config.gh-pages.yml`, though this might not be necessary
- [ ] Test, by commiting to master without building locally

Things to do later:
- [ ] Set up deployment to production similarly, and remove built files from `master`. `master` will have only markdown. This will also eliminate the need to have Jekyll to change minor things.
- [ ] Add a nice ![travis](https://api.travis-ci.org/pulsejet/WnCC.svg?branch=master) badge to the README
- [ ] Update README with new instructions.
- [ ] Rewrite all history to cleanup `_site` and bring the repository to a sane size (optional)

EDIT: Netlify offers a better, zero setup way to build including pull request previews. This PR also takes case of the other changes required for this (`Gemfile`)