### PR TITLE
Fix WnCC Website link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WnCC Website
 
-The official website for [WnCC: www.wncc-iitb.org](www.wncc-iitb.org) resides in this repository.  
+The official website for [WnCC: www.wncc-iitb.org](https://www.wncc-iitb.org) resides in this repository.  
 This website is completely static and runs on jekyll.
 
 ## Content: 


### PR DESCRIPTION
Currently the link goes to https://github.com/nihal111/WnCC/blob/master/www.wncc-iitb.org