### PR TITLE
Website Optimization 

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,7 +14,7 @@
     <script src="{{ site.baseurl }}/js/skel.min.js"></script>
     <script src="{{ site.baseurl }}/js/skel-layers.min.js"></script>
     <!-- <script src="{{ site.baseurl }}/js/init.js"></script> -->
-    <script src="{{ site.baseurl }}/css/init.css"></script>
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="{{ site.baseurl }}/css/skel.css" />
     </noscript>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,7 +13,8 @@
     <script src="{{ site.baseurl }}/js/jquery.min.js"></script>
     <script src="{{ site.baseurl }}/js/skel.min.js"></script>
     <script src="{{ site.baseurl }}/js/skel-layers.min.js"></script>
-    <script src="{{ site.baseurl }}/js/init.js"></script>
+    <!-- <script src="{{ site.baseurl }}/js/init.js"></script> -->
+    <script src="{{ site.baseurl }}/css/init.css"></script>
     <noscript>
         <link rel="stylesheet" href="{{ site.baseurl }}/css/skel.css" />
     </noscript>

--- a/_site/404.html
+++ b/_site/404.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/css/init.css
+++ b/_site/css/init.css
@@ -1,0 +1,6 @@
+@import url("style.css");
+@import url("style-xsmall.css") screen and (max-width: 480px);
+@import url("style-small.css")  screen and (max-width: 736px);
+@import url("style-medium.css") screen and (max-width: 980px);
+@import url("style-large.css")  screen and (max-width: 1280px);
+@import url("style-xlarge.css") screen and (max-width: 1680px);

--- a/_site/events/1-yahoohacku.html
+++ b/_site/events/1-yahoohacku.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/10-amangoelstalk.html
+++ b/_site/events/10-amangoelstalk.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/11-GoogleIOExtended17.html
+++ b/_site/events/11-GoogleIOExtended17.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/12-GoogleIOExtended14 .html
+++ b/_site/events/12-GoogleIOExtended14 .html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/13-ACMICPCBootCamp13.html
+++ b/_site/events/13-ACMICPCBootCamp13.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/14-sugarRushHackathon.html
+++ b/_site/events/14-sugarRushHackathon.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/15-codingGC14.html
+++ b/_site/events/15-codingGC14.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/16-sessionOnFreelancing.html
+++ b/_site/events/16-sessionOnFreelancing.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/17-hackWeekender().html
+++ b/_site/events/17-hackWeekender().html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/18-linuxDualBootAssistanceCamp.html
+++ b/_site/events/18-linuxDualBootAssistanceCamp.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/19-scratchday2017.html
+++ b/_site/events/19-scratchday2017.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/2-rattlesnake.html
+++ b/_site/events/2-rattlesnake.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/20-GIT17.html
+++ b/_site/events/20-GIT17.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/3-microsoftcfd.html
+++ b/_site/events/3-microsoftcfd.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/4-ciphers.html
+++ b/_site/events/4-ciphers.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/5-webdevhack.html
+++ b/_site/events/5-webdevhack.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/6-htmlcss.html
+++ b/_site/events/6-htmlcss.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/7-moztalk.html
+++ b/_site/events/7-moztalk.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/8-androidconclave.html
+++ b/_site/events/8-androidconclave.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/9-scratchday.html
+++ b/_site/events/9-scratchday.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/events/index.html
+++ b/_site/events/index.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/feed.xml
+++ b/_site/feed.xml
@@ -6,8 +6,8 @@
 </description>
     <link>http://localhost:4000/</link>
     <atom:link href="http://localhost:4000/feed.xml" rel="self" type="application/rss+xml" />
-    <pubDate>Wed, 15 Aug 2018 03:02:05 +0530</pubDate>
-    <lastBuildDate>Wed, 15 Aug 2018 03:02:05 +0530</lastBuildDate>
+    <pubDate>Wed, 15 Aug 2018 14:13:58 +0530</pubDate>
+    <lastBuildDate>Wed, 15 Aug 2018 14:13:58 +0530</lastBuildDate>
     <generator>Jekyll v3.8.3</generator>
     
   </channel>

--- a/_site/index.html
+++ b/_site/index.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/itsp-resources/index.html
+++ b/_site/itsp-resources/index.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/left-sidebar.html
+++ b/_site/left-sidebar.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/no-sidebar.html
+++ b/_site/no-sidebar.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/right-sidebar.html
+++ b/_site/right-sidebar.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/showcase/index.html
+++ b/_site/showcase/index.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/showcase_projects/1-HoldTheBeat-arpan.html
+++ b/_site/showcase_projects/1-HoldTheBeat-arpan.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/showcase_projects/2-JARVIS-nihal.html
+++ b/_site/showcase_projects/2-JARVIS-nihal.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/showcase_projects/3-Bellatrix-cheeku.html
+++ b/_site/showcase_projects/3-Bellatrix-cheeku.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/showcase_projects/4-Wirespace-Yash.html
+++ b/_site/showcase_projects/4-Wirespace-Yash.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc/faq.html
+++ b/_site/soc/faq.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc/index.html
+++ b/_site/soc/index.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/06-sucheta-akash-emoji-detector.html
+++ b/_site/soc_projects/06-sucheta-akash-emoji-detector.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/07-saurabh-faq-bot.html
+++ b/_site/soc_projects/07-saurabh-faq-bot.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/08-aviral-siddhant-semantics.html
+++ b/_site/soc_projects/08-aviral-siddhant-semantics.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/09-ritwick-shubham-mri-ct.html
+++ b/_site/soc_projects/09-ritwick-shubham-mri-ct.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/10-kushal- rumour.html
+++ b/_site/soc_projects/10-kushal- rumour.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/11-arka - 3D object reconstruction.html
+++ b/_site/soc_projects/11-arka - 3D object reconstruction.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/12-kalpesh-starmaps.html
+++ b/_site/soc_projects/12-kalpesh-starmaps.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/13-facerecog.html
+++ b/_site/soc_projects/13-facerecog.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/15-competitve.html
+++ b/_site/soc_projects/15-competitve.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/15-genres.html
+++ b/_site/soc_projects/15-genres.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/16-cheeku-montecarlo.html
+++ b/_site/soc_projects/16-cheeku-montecarlo.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/19-kalpesh-lang.html
+++ b/_site/soc_projects/19-kalpesh-lang.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/21-Bhishma Dedhia - Panorama in Camscanner.html
+++ b/_site/soc_projects/21-Bhishma Dedhia - Panorama in Camscanner.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/21-fossee-website.html
+++ b/_site/soc_projects/21-fossee-website.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/22-Sarthak Khandelwal - Texter.html
+++ b/_site/soc_projects/22-Sarthak Khandelwal - Texter.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/22-Sarthak Khandelwal-planner.html
+++ b/_site/soc_projects/22-Sarthak Khandelwal-planner.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/22-Tomar-IDS.html
+++ b/_site/soc_projects/22-Tomar-IDS.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/23-Varun Patil- InstiApp.html
+++ b/_site/soc_projects/23-Varun Patil- InstiApp.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/26-trehan-swag.html
+++ b/_site/soc_projects/26-trehan-swag.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/36-meet-camscanner.html
+++ b/_site/soc_projects/36-meet-camscanner.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/37-poisson-riddhish.html
+++ b/_site/soc_projects/37-poisson-riddhish.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/38-boost-riddhish.html
+++ b/_site/soc_projects/38-boost-riddhish.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/_site/soc_projects/39-BlindSource-riddhish.html
+++ b/_site/soc_projects/39-BlindSource-riddhish.html
@@ -16,7 +16,8 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <!-- <script src="/js/init.js"></script> -->
+    <link rel="stylesheet" href="/css/init.css" />
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
     </noscript>

--- a/css/init.css
+++ b/css/init.css
@@ -1,0 +1,6 @@
+@import url("style.css");
+@import url("style-xsmall.css") screen and (max-width: 480px);
+@import url("style-small.css")  screen and (max-width: 736px);
+@import url("style-medium.css") screen and (max-width: 980px);
+@import url("style-large.css")  screen and (max-width: 1280px);
+@import url("style-xlarge.css") screen and (max-width: 1680px);


### PR DESCRIPTION
Removed `init.js` from `head.html` in `_includes/` and added `init.css` which loads stylesheets based on screen size by media queries. 
Issue of content loading before image is resolved. 
Hosted in a github page, but page insights shows reduced score because of multiple render blocking css files (which were imported by media queries).
Page structure breakdown in most pages (because of other part of `init.js` not being loaded)